### PR TITLE
feat: add sherpa-onnx local TTS provider (free, offline, unlimited)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -97,11 +97,18 @@ Optional: **ElevenLabs** for higher quality, more natural voices:
   --host-voice echo --cohost-voice shimmer
 ```
 
+```bash
+# Use local sherpa-onnx TTS (free, offline, unlimited)
+<skill>/scripts/generate.py --url "https://..." --sherpa
+```
+
 **OpenAI voices:** alloy, echo, fable, onyx, nova, shimmer
 
 **ElevenLabs voices (premade):** Roger, Sarah, Laura, Charlie, George, Callum, River, Liam, Alice, Matilda, Will, Jessica, Eric, Bella, Chris, Brian, Daniel, Lily, Adam, Bill
 
-Browse all: https://elevenlabs.io/voice-library
+**Sherpa-onnx (local):** Uses Piper VITS models. Voice paths configured in `config/conversation.yaml` under `text_to_speech.sherpa`. Requires `sherpa-onnx-offline-tts` binary (set `SHERPA_ONNX_TTS_BIN` or install to `~/.openclaw/tools/sherpa-onnx-tts/`).
+
+Browse ElevenLabs voices: https://elevenlabs.io/voice-library
 
 ### All CLI Options
 
@@ -116,6 +123,7 @@ Browse all: https://elevenlabs.io/voice-library
 | `--host-name` | Host name (Person1) | `--host-name Alex` |
 | `--cohost-name` | Co-host name (Person2) | `--cohost-name Kiki` |
 | `--elevenlabs` | Use ElevenLabs TTS | `--elevenlabs` |
+| `--sherpa` | Use local sherpa-onnx TTS (free) | `--sherpa` |
 | `--host-voice` | Voice for host | `--host-voice Daniel` |
 | `--cohost-voice` | Voice for co-host | `--cohost-voice Alice` |
 | `--output`, `-o` | Output file path | `-o podcast.ogg` |
@@ -149,6 +157,7 @@ Key config options:
 | `OPENAI_API_KEY` | Yes | TTS audio generation (default) |
 | `GEMINI_API_KEY` | Yes | Transcript/dialogue generation |
 | `ELEVENLABS_API_KEY` | No | ElevenLabs TTS (required for `--elevenlabs`) |
+| `SHERPA_ONNX_TTS_BIN` | No | Path to sherpa-onnx-offline-tts binary (for `--sherpa`) |
 
 Get your ElevenLabs API key at: https://elevenlabs.io/app/settings/api-keys
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -107,6 +107,7 @@ Optional: **ElevenLabs** for higher quality, more natural voices:
 **ElevenLabs voices (premade):** Roger, Sarah, Laura, Charlie, George, Callum, River, Liam, Alice, Matilda, Will, Jessica, Eric, Bella, Chris, Brian, Daniel, Lily, Adam, Bill
 
 **Sherpa-onnx (local):** Uses Piper VITS models. Voice paths configured in `config/conversation.yaml` under `text_to_speech.sherpa`. Requires `sherpa-onnx-offline-tts` binary (set `SHERPA_ONNX_TTS_BIN` or install to `~/.openclaw/tools/sherpa-onnx-tts/`).
+Performance note: CPU-based synthesis, typically ~2-10x realtime, requires ~2GB+ RAM, and quality is good but generally below ElevenLabs.
 
 Browse ElevenLabs voices: https://elevenlabs.io/voice-library
 

--- a/config/conversation.yaml
+++ b/config/conversation.yaml
@@ -81,7 +81,7 @@ language_voices:
   sherpa:
     German:
       question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-thorsten_emotional-medium"
-      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-kerstin-low"
+      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-ramona-low"
 
 # ── Audio Output ──────────────────────────────────────────────────
 audio_format: "mp3"  # Converted to OGG after generation

--- a/config/conversation.yaml
+++ b/config/conversation.yaml
@@ -63,7 +63,7 @@ text_to_speech:
     model: "sherpa"
     default_voices:
       question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_GB-alan-medium"
-      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-lessac-high"
+      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-libritts_r-medium"
 
 # ── Language-Specific Voice Overrides ─────────────────────────────
 # Override default voices per language. Only applies when no explicit

--- a/config/conversation.yaml
+++ b/config/conversation.yaml
@@ -62,7 +62,7 @@ text_to_speech:
   sherpa:
     model: "sherpa"
     default_voices:
-      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-libritts_r-medium:sid=50"
+      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_GB-alan-medium"
       answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-lessac-high"
 
 # ── Language-Specific Voice Overrides ─────────────────────────────
@@ -80,7 +80,7 @@ language_voices:
   #     answer: "Alice"
   sherpa:
     German:
-      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-thorsten-high"
+      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-thorsten_emotional-medium"
       answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-kerstin-low"
 
 # ── Audio Output ──────────────────────────────────────────────────

--- a/config/conversation.yaml
+++ b/config/conversation.yaml
@@ -57,6 +57,14 @@ text_to_speech:
       question: "Daniel"    # Host: steady broadcaster (British)
       answer: "Alice"       # Co-host: clear educator (British)
 
+  # Local TTS via sherpa-onnx (free, offline, unlimited)
+  # Voice format: "/path/to/model_dir" or "/path/to/model_dir:sid=N"
+  sherpa:
+    model: "sherpa"
+    default_voices:
+      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-libritts_r-medium:sid=50"
+      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-en_US-lessac-high"
+
 # ── Language-Specific Voice Overrides ─────────────────────────────
 # Override default voices per language. Only applies when no explicit
 # --host-voice / --cohost-voice is passed on the CLI.
@@ -70,6 +78,10 @@ language_voices:
   #   German:
   #     question: "Daniel"
   #     answer: "Alice"
+  sherpa:
+    German:
+      question: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-thorsten-high"
+      answer: "~/.openclaw/tools/sherpa-onnx-tts/models/vits-piper-de_DE-kerstin-low"
 
 # ── Audio Output ──────────────────────────────────────────────────
 audio_format: "mp3"  # Converted to OGG after generation

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -252,7 +252,7 @@ def generate_podcast(
         overrides["roles_person2"] = build_role("co-host", cohost_name)
 
     # Voice overrides for the active TTS provider
-    provider = "elevenlabs" if tts_model == "elevenlabs" else "openai"
+    provider = tts_model if tts_model in ("elevenlabs", "sherpa") else "openai"
     if host_voice or cohost_voice:
         # Explicit CLI voices take highest priority
         voices: dict = {}

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -62,6 +62,9 @@ def check_environment(use_elevenlabs: bool = False):
         print("❌ GEMINI_API_KEY not set", file=sys.stderr)
         sys.exit(1)
 
+    # langchain_google_genai reads GOOGLE_API_KEY, while this skill uses GEMINI_API_KEY.
+    os.environ.setdefault("GOOGLE_API_KEY", os.environ.get("GEMINI_API_KEY", ""))
+
     if use_elevenlabs and not os.environ.get("ELEVENLABS_API_KEY"):
         print("❌ ELEVENLABS_API_KEY not set (required for --elevenlabs)", file=sys.stderr)
         sys.exit(1)
@@ -192,8 +195,9 @@ if tts_model == "sherpa":
     # which fails for sherpa since Config doesn't know about it. Patch it.
     from podcastfy.utils.config import Config
     Config.SHERPA_API_KEY = None
-    # sherpa outputs WAV but pydub/ffmpeg auto-detects format from content,
-    # so we leave audio_format as mp3 to keep podcastfy's output pipeline intact.
+    # sherpa-onnx provider emits WAV bytes.
+    config["audio_format"] = "wav"
+    config.setdefault("text_to_speech", {})["audio_format"] = "wav"
 
 # Generate podcast
 try:

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -47,14 +47,19 @@ LANGUAGE_MAP = {
 }
 
 
-def check_environment(use_elevenlabs: bool = False):
+def check_environment(use_elevenlabs: bool = False, use_sherpa: bool = False):
     """Verify environment is properly set up."""
     if not VENV_DIR.exists():
         print(f"❌ Virtual environment not found at {VENV_DIR}", file=sys.stderr)
         print(f"   Run: {SKILL_DIR}/scripts/install.sh", file=sys.stderr)
         sys.exit(1)
 
-    if not os.environ.get("OPENAI_API_KEY"):
+    if use_elevenlabs and use_sherpa:
+        print("❌ --elevenlabs and --sherpa are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
+    # Sherpa is fully local — only needs GEMINI_API_KEY for transcript generation
+    if not use_sherpa and not os.environ.get("OPENAI_API_KEY"):
         print("❌ OPENAI_API_KEY not set", file=sys.stderr)
         sys.exit(1)
 
@@ -412,7 +417,7 @@ def main():
     if not any([args.urls, args.text, args.pdf]):
         parser.error("At least one of --url, --text, or --pdf is required")
 
-    check_environment(use_elevenlabs=args.elevenlabs)
+    check_environment(use_elevenlabs=args.elevenlabs, use_sherpa=args.sherpa)
 
     # Determine TTS model
     if args.sherpa:

--- a/scripts/tts_providers/sherpa_onnx.py
+++ b/scripts/tts_providers/sherpa_onnx.py
@@ -1,0 +1,150 @@
+"""Sherpa-ONNX local TTS provider for podcastfy.
+
+Runs entirely offline using sherpa-onnx-offline-tts binary + Piper VITS models.
+Zero API cost, unlimited usage, runs on CPU.
+
+Requires:
+    - SHERPA_ONNX_TTS_BIN: Path to sherpa-onnx-offline-tts binary
+    - Model directories with .onnx, tokens.txt, and espeak-ng-data/
+
+Voice format: "<model_dir>" or "<model_dir>:sid=<N>" for multi-speaker models.
+Example voices:
+    - "/path/to/vits-piper-en_US-lessac-high"
+    - "/path/to/vits-piper-en_US-libritts_r-medium:sid=50"
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from podcastfy.tts.base import TTSProvider
+
+
+def _find_model_files(model_dir: str) -> dict:
+    """Find .onnx, tokens.txt, and espeak-ng-data in a model directory."""
+    p = Path(model_dir)
+    if not p.is_dir():
+        raise ValueError(f"Model directory not found: {model_dir}")
+
+    onnx_files = list(p.glob("*.onnx"))
+    if not onnx_files:
+        raise ValueError(f"No .onnx file found in {model_dir}")
+
+    tokens = p / "tokens.txt"
+    if not tokens.exists():
+        raise ValueError(f"tokens.txt not found in {model_dir}")
+
+    espeak_dir = p / "espeak-ng-data"
+    if not espeak_dir.is_dir():
+        raise ValueError(f"espeak-ng-data/ not found in {model_dir}")
+
+    return {
+        "model": str(onnx_files[0]),
+        "tokens": str(tokens),
+        "data_dir": str(espeak_dir),
+    }
+
+
+def _parse_voice(voice: str) -> tuple[str, int]:
+    """Parse voice string into (model_dir, speaker_id).
+
+    Supports:
+        "/path/to/model"           → (path, 0)
+        "/path/to/model:sid=50"    → (path, 50)
+        "~/path/to/model:sid=50"   → (expanded, 50)
+    """
+    if ":sid=" in voice:
+        parts = voice.rsplit(":sid=", 1)
+        return os.path.expanduser(parts[0]), int(parts[1])
+    return os.path.expanduser(voice), 0
+
+
+class SherpaOnnxTTS(TTSProvider):
+    """Local TTS via sherpa-onnx-offline-tts binary."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "sherpa"):
+        """Initialize. api_key is ignored (local provider)."""
+        self.tts_bin = os.environ.get(
+            "SHERPA_ONNX_TTS_BIN",
+            os.path.expanduser(
+                "~/.openclaw/tools/sherpa-onnx-tts/runtime/bin/sherpa-onnx-offline-tts"
+            ),
+        )
+        if not Path(self.tts_bin).exists():
+            raise RuntimeError(
+                f"sherpa-onnx-offline-tts not found at {self.tts_bin}. "
+                "Set SHERPA_ONNX_TTS_BIN or install sherpa-onnx."
+            )
+
+    def get_supported_tags(self) -> List[str]:
+        """No SSML support for local TTS."""
+        return []
+
+    def generate_audio(self, text: str, voice: str, model: str, voice2: str = None) -> bytes:
+        """Generate audio using sherpa-onnx-offline-tts.
+
+        Args:
+            text: Text to synthesize.
+            voice: Model directory path, optionally with ":sid=N" suffix.
+            model: Ignored (model is determined by voice path).
+            voice2: Ignored.
+
+        Returns:
+            WAV audio bytes.
+        """
+        if not text or not text.strip():
+            raise ValueError("Text cannot be empty")
+        if not voice:
+            raise ValueError("Voice (model directory path) must be specified")
+
+        model_dir, sid = _parse_voice(voice)
+        files = _find_model_files(model_dir)
+
+        # Strip any SSML tags that might have leaked through
+        clean_text = re.sub(r"<[^>]+>", "", text).strip()
+        if not clean_text:
+            raise ValueError("Text is empty after stripping markup")
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            cmd = [
+                self.tts_bin,
+                f"--vits-model={files['model']}",
+                f"--vits-tokens={files['tokens']}",
+                f"--vits-data-dir={files['data_dir']}",
+                f"--sid={sid}",
+                f"--output-filename={tmp_path}",
+                clean_text,
+            ]
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"sherpa-onnx-offline-tts failed (rc={result.returncode}): "
+                    f"{result.stderr[:500]}"
+                )
+
+            with open(tmp_path, "rb") as f:
+                wav_bytes = f.read()
+
+            if len(wav_bytes) < 100:
+                raise RuntimeError("Generated audio file is suspiciously small")
+
+            return wav_bytes
+
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass

--- a/scripts/tts_providers/sherpa_onnx.py
+++ b/scripts/tts_providers/sherpa_onnx.py
@@ -62,11 +62,17 @@ def _parse_voice(voice: str) -> tuple[str, int]:
     return os.path.expanduser(voice), 0
 
 
-class SherpaOnnxTTS(TTSProvider):
-    """Local TTS via sherpa-onnx-offline-tts binary."""
+class SherpaTTS(TTSProvider):
+    """Local TTS via sherpa-onnx-offline-tts binary.
+
+    Class name is SherpaTTS (not SherpaOnnxTTS) because podcastfy resolves
+    config keys via ClassName.lower().replace('tts','') → 'sherpa', which
+    must match the 'sherpa:' section in conversation.yaml.
+    """
 
     def __init__(self, api_key: Optional[str] = None, model: str = "sherpa"):
         """Initialize. api_key is ignored (local provider)."""
+        self.model = model  # Required by podcastfy's text_to_speech.py
         self.tts_bin = os.environ.get(
             "SHERPA_ONNX_TTS_BIN",
             os.path.expanduser(


### PR DESCRIPTION
## Summary

Adds a local TTS option using sherpa-onnx + Piper VITS models. Zero API cost, runs entirely on CPU, unlimited usage.

## Usage

```bash
# Local TTS (free)
generate.py --url https://... --sherpa

# Local TTS with German
generate.py --url https://... --sherpa --lang de
```

## Architecture

Implements podcastfy's `TTSProvider` ABC and registers via `TTSProviderFactory.register_provider()`. The provider:
1. Parses voice string → model directory + optional speaker ID
2. Calls `sherpa-onnx-offline-tts` binary with the model's .onnx, tokens.txt, and espeak-ng-data
3. Returns WAV bytes
4. Podcastfy handles the rest (concatenation, format conversion)

## Voice Configuration

Voice format: `/path/to/model_dir` or `/path/to/model_dir:sid=N` for multi-speaker models.

Default voices:
| Language | Host | Co-host |
|----------|------|---------|
| English | libritts_r (speaker 50) | lessac (female, high quality) |
| German | thorsten-high (male) | kerstin-low (female) |

## Cost Comparison

| Provider | Cost/min | Quality | Offline? |
|----------|----------|---------|----------|
| sherpa-onnx | $0 | Decent | ✅ |
| OpenAI tts-1-hd | ~$0.03 | Good | ❌ |
| ElevenLabs | ~$0.17 | Best | ❌ |

## Files

- `scripts/tts_providers/sherpa_onnx.py` — Provider implementation
- `config/conversation.yaml` — Default sherpa voices (EN + DE)
- `scripts/generate.py` — `--sherpa` flag + provider registration in VENV_CODE

## Requirements

- `sherpa-onnx-offline-tts` binary (set `SHERPA_ONNX_TTS_BIN` or install to `~/.openclaw/tools/sherpa-onnx-tts/`)
- Piper VITS models in `~/.openclaw/tools/sherpa-onnx-tts/models/`